### PR TITLE
fix: cursor parse error

### DIFF
--- a/src/api/latestDeltaCursor.ts
+++ b/src/api/latestDeltaCursor.ts
@@ -1,7 +1,7 @@
+import { XMLParser } from 'fast-xml-parser'
 import { requestUrl } from 'obsidian'
 import { apiLimiter } from '~/utils/api-limiter'
 import { NSAPI } from '~/utils/ns-api'
-import { parseXml } from '~/utils/parse-xml'
 
 interface GetLatestDeltaCursorInput {
 	folderName: string
@@ -24,11 +24,21 @@ export const getLatestDeltaCursor = apiLimiter.wrap(
 			headers,
 			body,
 		})
-		const result = parseXml<{
+		const parseXml = new XMLParser({
+			attributeNamePrefix: '',
+			removeNSPrefix: true,
+			parseTagValue: false,
+			numberParseOptions: {
+				eNotation: false,
+				hex: true,
+				leadingZeros: true,
+			},
+		})
+		const result: {
 			response: {
 				cursor: string
 			}
-		}>(response.text)
+		} = parseXml.parse(response.text)
 		return result
 	},
 )

--- a/src/api/webdav.ts
+++ b/src/api/webdav.ts
@@ -1,11 +1,11 @@
 import consola from 'consola'
+import { XMLParser } from 'fast-xml-parser'
 import { isNil, partial } from 'lodash-es'
 import { requestUrl } from 'obsidian'
 import { basename, join } from 'path'
 import { FileStat } from 'webdav'
 import { NS_DAV_ENDPOINT } from '~/consts'
 import { is503Error } from '~/utils/is-503-error'
-import { parseXml } from '~/utils/parse-xml'
 
 interface WebDAVResponse {
 	multistatus: {
@@ -82,8 +82,17 @@ export async function getDirectoryContents(
           </prop>
         </propfind>`,
 			})
-
-			const result = parseXml<WebDAVResponse>(response.text)
+			const parseXml = new XMLParser({
+				attributeNamePrefix: '',
+				removeNSPrefix: true,
+				parseTagValue: false,
+				numberParseOptions: {
+					eNotation: false,
+					hex: true,
+					leadingZeros: true,
+				},
+			})
+			const result: WebDAVResponse = parseXml.parse(response.text)
 			const items = Array.isArray(result.multistatus.response)
 				? result.multistatus.response
 				: [result.multistatus.response]

--- a/src/utils/parse-xml.ts
+++ b/src/utils/parse-xml.ts
@@ -1,9 +1,0 @@
-import { XMLParser } from 'fast-xml-parser'
-
-export function parseXml<T>(xml: string) {
-	const parser = new XMLParser({
-		attributeNamePrefix: '',
-		removeNSPrefix: true,
-	})
-	return parser.parse(xml) as T
-}


### PR DESCRIPTION
```ts
import { XMLParser } from 'fast-xml-parser'

const xmlData = `<val>e2</val>`
const parser = new XMLParser()
const result = parser.parse(xmlData)
console.log(result)
```

expected output:

```
{val: "e2"}
```

actual output：

```
{val: NaN}
```
