### PR TITLE
feat(ai): auto-trigger the AI agent when new memos accumulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ _This plugin enables two-way synchronization between Obsidian notes and Nutstore
 AI 助手是一个内置的智能代理，让你通过自然语言管理 Obsidian Vault。支持任意兼容 OpenAI 接口的服务商，可自主完成复杂的多步骤任务。
 _The AI Agent is a built-in assistant that lets you manage your Obsidian vault through natural language. It supports any OpenAI-compatible provider and can handle complex, multi-step tasks autonomously._
 
-Agent 在做出任何更改前都会请求用户确认。你可以逐条批准、按操作类型批准当前会话，或在设置中开启 *YOLO 模式* 全部自动通过。
-_Before the agent makes any changes, it asks for your approval. You can approve individual operations, approve an operation type for the entire session, or enable _YOLO mode_ in settings to auto-approve everything._
+Agent 在做出任何更改前都会请求用户确认。你可以逐条批准、按操作类型批准当前会话，或在设置中开启 _YOLO 模式_ 全部自动通过。
+_Before the agent makes any changes, it asks for your approval. You can approve individual operations, approve an operation type for the entire session, or enable *YOLO mode* in settings to auto-approve everything._
 
 **配置方法 | Setup：**
 
@@ -58,6 +58,21 @@ _Before the agent makes any changes, it asks for your approval. You can approve 
    _Add an AI provider (any OpenAI-compatible endpoint) and fill in the model name_
 3. 从左侧边栏打开 AI 对话框，开始对话
    _Open the AI chat panel from the left sidebar and start chatting_
+
+### ⚡ 备忘录自动触发 | Memo Auto-Trigger
+
+当 vault 中新增笔记达到设定阈值时，插件会自动让 AI Agent 处理它们——例如触发一次「总结备忘录」流程，将笔记整理成任务。
+
+_When enough new notes are created in the vault, the plugin automatically asks the AI Agent to process them — e.g. triggering a "summarize memos" flow that turns notes into tasks._
+
+- 在设置 → **AI** 标签页启用，可配置阈值（默认 10）与触发消息
+  _Enable it in Settings → **AI** tab; configure the threshold (default 10) and the trigger message_
+- 只有 `.obsidian/`、`.agents/` 目录之外的 `.md` 文件会计数（`欢迎.md` 不计入）
+  _Only `.md` files outside `.obsidian/` and `.agents/` are counted (`欢迎.md` is ignored)_
+- 触发消息与某个 Skill 的描述匹配时，Agent 会自动加载该 Skill 执行
+  _If the trigger message matches a Skill description, the Agent loads that Skill automatically_
+- 注意：自动触发仍需遵循常规权限模式——Agent 执行写入操作前会请求确认（除非已开启 YOLO 模式）；自动触发仅在 Obsidian 运行且 AI 服务商已配置时生效
+  _Note: the auto-trigger still respects the regular permission mode — the Agent asks for approval before write actions (unless YOLO mode is enabled); it only fires while Obsidian is running with an AI provider configured_
 
 ---
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -312,6 +312,21 @@
 				"networkDisconnected": "Network connection unavailable. Check your connection and try again.",
 				"browserCorsFallbackToBuiltinTransport": "Browser CORS request failed. Temporarily fell back to the built-in request transport.",
 				"browserCorsFailedWithDisableLink": "Browser CORS request failed. [Open this provider and disable CORS]({{link}})."
+			},
+			"memoTrigger": {
+				"section": "Memo Auto-Trigger",
+				"enabled": {
+					"name": "Enable auto-trigger",
+					"desc": "When this many new notes are created in the vault, automatically ask the AI agent to process them. The agent loads the matching Skill (e.g. memo-to-todo) via its trigger message."
+				},
+				"threshold": {
+					"name": "Trigger threshold",
+					"desc": "Number of new memo notes that triggers the agent (default 10). Only .md files outside .obsidian/ and .agents/ are counted; 欢迎.md is ignored."
+				},
+				"message": {
+					"name": "Trigger message",
+					"desc": "Message sent to the agent when the threshold is reached. Match it to a Skill description to make the agent load that Skill automatically."
+				}
 			}
 		},
 		"logout": {
@@ -821,5 +836,10 @@
 		"labels": {
 			"currentPath": "Current Path"
 		}
+	},
+	"memoTrigger": {
+		"triggered": "Memo auto-trigger: agent is processing the new notes.",
+		"triggerRejected": "Memo auto-trigger: the message was not accepted (check the AI provider settings).",
+		"triggerError": "Memo auto-trigger failed. See the logs for details."
 	}
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -270,6 +270,21 @@
 				"networkDisconnected": "网络连接不可用，请检查网络后重试。",
 				"browserCorsFallbackToBuiltinTransport": "浏览器跨域请求失败，已临时回退到内置请求方式。",
 				"browserCorsFailedWithDisableLink": "浏览器跨域请求失败。[打开此提供商并关闭 CORS]({{link}})。"
+			},
+			"memoTrigger": {
+				"section": "备忘录自动触发",
+				"enabled": {
+					"name": "启用自动触发",
+					"desc": "当 vault 中新增笔记达到阈值时，自动让 AI agent 处理它们。agent 会根据触发消息自动加载匹配的 Skill（如 memo-to-todo）。"
+				},
+				"threshold": {
+					"name": "触发阈值",
+					"desc": "新增多少条备忘录笔记后触发 agent（默认 10）。只统计 .obsidian/ 与 .agents/ 之外的 .md 文件，欢迎.md 不计入。"
+				},
+				"message": {
+					"name": "触发消息",
+					"desc": "达到阈值时发给 agent 的消息。与某个 Skill 的描述匹配时，agent 会自动加载该 Skill 执行。"
+				}
 			}
 		},
 		"confirmBeforeSync": {
@@ -821,5 +836,10 @@
 		"labels": {
 			"currentPath": "当前路径"
 		}
+	},
+	"memoTrigger": {
+		"triggered": "备忘录自动触发：agent 正在处理新增笔记。",
+		"triggerRejected": "备忘录自动触发：消息未被接受（请检查 AI 服务商配置）。",
+		"triggerError": "备忘录自动触发失败，详情见日志。"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import GcService from './services/gc.service'
 import I18nService from './services/i18n.service'
 import LoggerService from './services/logger.service'
 import McpService from './services/mcp.service'
+import MemoTriggerService from './services/memo-trigger.service'
 import ModelsPresetService from './services/models-preset.service'
 import NutstoreLlmGatewayService from './services/nutstore-llm-gateway.service'
 import { ProgressService } from './services/progress.service'
@@ -64,6 +65,7 @@ export default class NutstorePlugin extends Plugin {
 	public syncExecutorService = new SyncExecutorService(this)
 	public gcService = new GcService(this)
 	public chatService = new ChatService(this)
+	public memoTriggerService = new MemoTriggerService(this)
 	public aiConflictResolverService = new AIConflictResolverService(this)
 	public realtimeSyncService = new RealtimeSyncService(
 		this,
@@ -93,6 +95,7 @@ export default class NutstorePlugin extends Plugin {
 			this.realtimeSyncService,
 			this.mcpService,
 			this.chatService,
+			this.memoTriggerService,
 			this.aiConflictResolverService,
 			this.scheduledSyncService,
 		]

--- a/src/services/memo-trigger.service.test.ts
+++ b/src/services/memo-trigger.service.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TFile } from 'obsidian'
+import MemoTriggerService, {
+	isMemoCandidatePath,
+	type MemoTriggerState,
+} from './memo-trigger.service'
+
+const kv = vi.hoisted(() => ({
+	get: vi.fn(),
+	set: vi.fn(),
+}))
+
+vi.mock('~/storage/kv', () => ({
+	memoTriggerKV: { get: kv.get, set: kv.set },
+}))
+
+function makeFile(path: string): TFile {
+	const file = new TFile()
+	;(file as unknown as { path: string }).path = path
+	;(file as unknown as { extension: string }).extension = 'md'
+	return file
+}
+
+interface FakePlugin {
+	settings: {
+		ai: {
+			memoTrigger: {
+				enabled: boolean
+				threshold: number
+				message: string
+			}
+		}
+	}
+	app: { vault: { on: ReturnType<typeof vi.fn> } }
+	registerEvent: ReturnType<typeof vi.fn>
+	chatService: { sendMessage: ReturnType<typeof vi.fn> }
+}
+
+function createFakePlugin(
+	overrides: Partial<FakePlugin['settings']['ai']['memoTrigger']> = {},
+): {
+	plugin: FakePlugin
+	vaultOn: FakePlugin['app']['vault']['on']
+	sendMessage: FakePlugin['chatService']['sendMessage']
+} {
+	const vaultOn = vi.fn()
+	const sendMessage = vi.fn().mockResolvedValue(true)
+	const plugin: FakePlugin = {
+		settings: {
+			ai: {
+				memoTrigger: {
+					enabled: true,
+					threshold: 2,
+					message: '总结备忘录',
+					...overrides,
+				},
+			},
+		},
+		app: { vault: { on: vaultOn } },
+		registerEvent: vi.fn(),
+		chatService: { sendMessage },
+	}
+	return { plugin, vaultOn, sendMessage }
+}
+
+async function loadService(plugin: FakePlugin) {
+	const service = new MemoTriggerService(
+		plugin as unknown as ConstructorParameters<typeof MemoTriggerService>[0],
+	)
+	await service.onload()
+	return service
+}
+
+function createHandler(
+	vaultOn: FakePlugin['app']['vault']['on'],
+): (file: TFile) => void {
+	return vaultOn.mock.calls[0][1]
+}
+
+describe('isMemoCandidatePath', () => {
+	it('accepts plain markdown notes anywhere in the vault', () => {
+		expect(isMemoCandidatePath('memo.md')).toBe(true)
+		expect(isMemoCandidatePath('notes/2026-08-28.md')).toBe(true)
+	})
+
+	it('rejects non-markdown files', () => {
+		expect(isMemoCandidatePath('image.png')).toBe(false)
+		expect(isMemoCandidatePath('notes/data.json')).toBe(false)
+	})
+
+	it('rejects files under .obsidian and .agents', () => {
+		expect(isMemoCandidatePath('.obsidian/workspace.json')).toBe(false)
+		expect(isMemoCandidatePath('.agents/skills/memo-to-todo/SKILL.md')).toBe(
+			false,
+		)
+	})
+
+	it('rejects the vault welcome note', () => {
+		expect(isMemoCandidatePath('欢迎.md')).toBe(false)
+		expect(isMemoCandidatePath('welcome.md')).toBe(false)
+	})
+})
+
+describe('MemoTriggerService', () => {
+	beforeEach(() => {
+		kv.get.mockReset().mockResolvedValue(undefined)
+		kv.set.mockReset().mockResolvedValue(undefined)
+	})
+
+	it('does not count notes when the trigger is disabled', async () => {
+		const { plugin, vaultOn, sendMessage } = createFakePlugin({
+			enabled: false,
+		})
+		await loadService(plugin)
+		const handler = createHandler(vaultOn)
+
+		handler(makeFile('a.md'))
+		handler(makeFile('b.md'))
+
+		expect(sendMessage).not.toHaveBeenCalled()
+		expect(kv.set).not.toHaveBeenCalled()
+	})
+
+	it('does not count non-candidate files', async () => {
+		const { plugin, vaultOn, sendMessage } = createFakePlugin({
+			threshold: 2,
+		})
+		await loadService(plugin)
+		const handler = createHandler(vaultOn)
+
+		handler(makeFile('.agents/skills/x/SKILL.md'))
+		handler(makeFile('欢迎.md'))
+		handler(makeFile('only-one-memo.md'))
+
+		expect(sendMessage).not.toHaveBeenCalled()
+	})
+
+	it('triggers the agent once the threshold of new notes is reached', async () => {
+		const { plugin, vaultOn, sendMessage } = createFakePlugin({
+			threshold: 2,
+		})
+		await loadService(plugin)
+		const handler = createHandler(vaultOn)
+
+		handler(makeFile('memo-1.md'))
+		expect(sendMessage).not.toHaveBeenCalled()
+
+		handler(makeFile('memo-2.md'))
+		await vi.waitFor(() => {
+			expect(sendMessage).toHaveBeenCalledTimes(1)
+		})
+		expect(sendMessage).toHaveBeenCalledWith('总结备忘录')
+
+		// Count is reset after triggering: two more notes trigger again.
+		handler(makeFile('memo-3.md'))
+		handler(makeFile('memo-4.md'))
+		await vi.waitFor(() => {
+			expect(sendMessage).toHaveBeenCalledTimes(2)
+		})
+	})
+
+	it('restores the counted set from KV storage', async () => {
+		const stored: MemoTriggerState = { counted: ['memo-1.md'] }
+		kv.get.mockResolvedValue(stored)
+		const { plugin, vaultOn, sendMessage } = createFakePlugin({
+			threshold: 2,
+		})
+		await loadService(plugin)
+		const handler = createHandler(vaultOn)
+
+		// One note was already counted before a restart; one more triggers.
+		handler(makeFile('memo-2.md'))
+		await vi.waitFor(() => {
+			expect(sendMessage).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	it('persists the counted set after each creation', async () => {
+		const { plugin, vaultOn } = createFakePlugin({ threshold: 5 })
+		await loadService(plugin)
+		const handler = createHandler(vaultOn)
+
+		handler(makeFile('memo-1.md'))
+		expect(kv.set).toHaveBeenLastCalledWith('memo_trigger', {
+			counted: ['memo-1.md'],
+		})
+	})
+})

--- a/src/services/memo-trigger.service.ts
+++ b/src/services/memo-trigger.service.ts
@@ -1,0 +1,112 @@
+import { Notice, TAbstractFile, TFile } from 'obsidian'
+import type NutstorePlugin from '..'
+import i18n from '~/i18n'
+import { memoTriggerKV } from '~/storage/kv'
+import logger from '~/utils/logger'
+import { BaseService } from './service.interface'
+
+export const MEMO_TRIGGER_DEFAULT_MESSAGE = '总结备忘录'
+
+const MEMO_TRIGGER_KV_KEY = 'memo_trigger'
+
+export interface MemoTriggerState {
+	counted: string[]
+}
+
+/**
+ * Whether a vault file path should count toward the memo auto-trigger.
+ * Memos are plain `.md` notes; the config dirs (`.obsidian`, `.agents`) and
+ * the vault welcome note are excluded.
+ */
+export function isMemoCandidatePath(path: string): boolean {
+	const parts = path.split('/')
+	if (parts.some((part) => part === '.obsidian' || part === '.agents')) {
+		return false
+	}
+	if (!path.endsWith('.md')) {
+		return false
+	}
+	const name = parts[parts.length - 1]
+	if (name === '欢迎.md' || name === 'welcome.md') {
+		return false
+	}
+	return true
+}
+
+/**
+ * Watches vault note creation and, once enough new memos have accumulated,
+ * automatically asks the AI agent to process them (e.g. via the
+ * `memo-to-todo` skill that summarizes memos into Todoist tasks).
+ *
+ * This is an event-driven trigger — it fires while Obsidian is running and
+ * the plugin is loaded. The count survives restarts via KV storage.
+ */
+export default class MemoTriggerService extends BaseService {
+	private counted = new Set<string>()
+
+	constructor(private plugin: NutstorePlugin) {
+		super()
+	}
+
+	override async onload() {
+		try {
+			const stored = await memoTriggerKV.get(MEMO_TRIGGER_KV_KEY)
+			if (stored?.counted) {
+				this.counted = new Set(stored.counted)
+			}
+		} catch (error) {
+			logger.warn('Failed to restore memo trigger state', error)
+		}
+
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on('create', (file) => {
+				void this.handleCreatedFile(file)
+			}),
+		)
+	}
+
+	private async handleCreatedFile(file: TAbstractFile) {
+		const memoTrigger = this.plugin.settings.ai.memoTrigger
+		if (!memoTrigger?.enabled) {
+			return
+		}
+		if (!(file instanceof TFile) || !isMemoCandidatePath(file.path)) {
+			return
+		}
+
+		this.counted.add(file.path)
+		await this.persist()
+
+		const threshold = memoTrigger.threshold > 0 ? memoTrigger.threshold : 10
+		if (this.counted.size >= threshold) {
+			await this.trigger(memoTrigger.message || MEMO_TRIGGER_DEFAULT_MESSAGE)
+		}
+	}
+
+	private async trigger(message: string) {
+		this.counted.clear()
+		await this.persist()
+
+		try {
+			const accepted = await this.plugin.chatService.sendMessage(message)
+			if (accepted) {
+				new Notice(i18n.t('memoTrigger.triggered'))
+			} else {
+				new Notice(i18n.t('memoTrigger.triggerRejected'))
+			}
+		} catch (error) {
+			logger.error('Memo auto-trigger failed', error)
+			new Notice(i18n.t('memoTrigger.triggerError'))
+		}
+	}
+
+	private async persist() {
+		try {
+			await memoTriggerKV.set(MEMO_TRIGGER_KV_KEY, {
+				counted: [...this.counted],
+			})
+		} catch (error) {
+			logger.warn('Failed to persist memo trigger state', error)
+		}
+	}
+}

--- a/src/settings/ai.ts
+++ b/src/settings/ai.ts
@@ -139,6 +139,55 @@ export default class AISettings extends BaseSettings {
 						await this.persist(false)
 					}),
 			)
+
+		this.displayMemoTriggerSettings()
+	}
+
+	private displayMemoTriggerSettings() {
+		const memoTrigger = this.plugin.settings.ai.memoTrigger ?? {
+			enabled: false,
+			threshold: 10,
+			// Keep in sync with DEFAULT_SETTINGS.ai.memoTrigger.message
+			message: '总结备忘录',
+		}
+
+		new Setting(this.containerEl)
+			.setName(i18n.t('settings.ai.memoTrigger.section'))
+			.setHeading()
+
+		new Setting(this.containerEl)
+			.setName(i18n.t('settings.ai.memoTrigger.enabled.name'))
+			.setDesc(i18n.t('settings.ai.memoTrigger.enabled.desc'))
+			.addToggle((toggle) =>
+				toggle.setValue(memoTrigger.enabled).onChange(async (value) => {
+					memoTrigger.enabled = value
+					this.plugin.settings.ai.memoTrigger = memoTrigger
+					await this.persist(false)
+				}),
+			)
+
+		new Setting(this.containerEl)
+			.setName(i18n.t('settings.ai.memoTrigger.threshold.name'))
+			.setDesc(i18n.t('settings.ai.memoTrigger.threshold.desc'))
+			.addText((text) =>
+				text.setValue(String(memoTrigger.threshold)).onChange(async (value) => {
+					const parsed = parseInt(value, 10)
+					memoTrigger.threshold = Number.isNaN(parsed) ? 10 : parsed
+					this.plugin.settings.ai.memoTrigger = memoTrigger
+					await this.persist(false)
+				}),
+			)
+
+		new Setting(this.containerEl)
+			.setName(i18n.t('settings.ai.memoTrigger.message.name'))
+			.setDesc(i18n.t('settings.ai.memoTrigger.message.desc'))
+			.addText((text) =>
+				text.setValue(memoTrigger.message).onChange(async (value) => {
+					memoTrigger.message = value
+					this.plugin.settings.ai.memoTrigger = memoTrigger
+					await this.persist(false)
+				}),
+			)
 	}
 
 	private listUserManagedProviders() {

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -52,10 +52,7 @@ export type SyncPolicyDescI18nKey =
 	| 'settings.syncPolicy.modal.receiveOnlyRevertLocalChangesDesc'
 
 export type ConflictStrategyI18nKey =
-	| 'noConflictMerge'
-	| 'diff3'
-	| 'localPriority'
-	| 'serverPriority'
+	'noConflictMerge' | 'diff3' | 'localPriority' | 'serverPriority'
 
 export function getConflictStrategyI18nKey(
 	strategy: ConflictStrategy,
@@ -152,6 +149,11 @@ export interface NutstoreSettings {
 		defaultModel?: { providerId: string; modelId: string }
 		yolo?: boolean
 		nutstoreLlmGateway?: NutstoreLlmGatewayAuthSettings
+		memoTrigger?: {
+			enabled: boolean
+			threshold: number
+			message: string
+		}
 	}
 	configDirSyncMode?: 'none' | 'bookmarks' | 'all'
 }
@@ -220,6 +222,11 @@ export const DEFAULT_SETTINGS: NutstoreSettings = {
 		defaultModel: undefined,
 		yolo: false,
 		nutstoreLlmGateway: {},
+		memoTrigger: {
+			enabled: false,
+			threshold: 10,
+			message: '总结备忘录',
+		},
 	},
 	configDirSyncMode: 'none',
 }

--- a/src/storage/kv.ts
+++ b/src/storage/kv.ts
@@ -51,3 +51,10 @@ export const chatSessionKV =
 export const chatMetaKV = createRecoverableStorage<
 	ChatMetaRecord | ChatSessionIndexItem[]
 >('chat_meta')
+
+export interface MemoTriggerRecord {
+	counted: string[]
+}
+
+export const memoTriggerKV =
+	createRecoverableStorage<MemoTriggerRecord>('memo_trigger')


### PR DESCRIPTION
## Summary

Adds a **Memo Auto-Trigger** to the built-in AI Agent: when enough new notes are created in the vault (default threshold: 10), the plugin automatically sends a trigger message to the agent — e.g. running a memo-summarization Skill that turns notes into tasks (the user's own `memo-to-todo` vault Skill matches the default trigger message `总结备忘录`).

## Motivation

Users who use the AI ChatBox to process a memo backlog (summarize notes into tasks) currently have to open the chat panel and type the trigger every time. This feature makes the pipeline hands-off: write notes in Obsidian, and once the threshold is reached the agent picks them up automatically.

## Implementation

- **`MemoTriggerService`** (new): listens to `app.vault.on('create')`, counts candidate notes, persists the count in KV (survives restarts), and calls `ChatService.sendMessage` with the configured trigger message when the threshold is reached. `sendMessage`/`SessionProcessor` are UI-independent, so the agent run works without the chat panel being open.
- **Candidate filter**: `.md` files only, excluding `.obsidian/` and `.agents/` paths and the vault welcome note (`欢迎.md`).
- **Settings** (`Settings > AI`): `ai.memoTrigger.{enabled, threshold, message}` — disabled by default, threshold 10, message `总结备忘录` (bilingual zh/en UI + notices).
- **Tests**: 9 new unit tests covering path filtering, disabled state, threshold triggering (with count reset), KV restore, and persistence.

## Notes

- The auto-trigger respects the regular permission mode: the agent still asks for confirmation before write actions unless YOLO mode is enabled.
- It fires only while Obsidian is running with an AI provider configured — it is an event-driven trigger, not a background scheduler.
- `npx vitest run` shows 7 pre-existing failures in `src/ai/providers/registry.test.ts`, `src/ai/skills/builtin.test.ts` and `src/ai/tools/bash/runtime.test.ts` that also fail on a clean tree; the new tests all pass.