### PR TITLE
fix: 遵循模型配置的输出 Token 上限

### DIFF
--- a/src/ai/chat/runtime/agent-runner.test.ts
+++ b/src/ai/chat/runtime/agent-runner.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChatSession } from '~/ai/chat/domain'
+import { AgentRunner } from '~/ai/chat/runtime/agent-runner'
+
+const toolLoopOptions = vi.hoisted(() => vi.fn())
+
+vi.mock('ai', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('ai')>()
+	return {
+		...actual,
+		isLoopFinished: vi.fn(() => vi.fn()),
+		ToolLoopAgent: class {
+			constructor(options: unknown) {
+				toolLoopOptions(options)
+			}
+
+			async stream(options: { onStepEnd: (step: unknown) => Promise<void> }) {
+				return {
+					stream: (async function* () {
+						await options.onStepEnd({
+							response: {
+								id: 'response',
+								modelId: 'model',
+								messages: [
+									{
+										role: 'assistant',
+										content: [{ type: 'text', text: 'done' }],
+									},
+								],
+							},
+							usage: {},
+							finishReason: 'stop',
+							content: [],
+						})
+						yield { type: 'text-delta', text: '' }
+					})(),
+				}
+			}
+		},
+	}
+})
+
+vi.mock('~/ai/chat/prompts', async (importOriginal) => ({
+	...(await importOriginal<typeof import('~/ai/chat/prompts')>()),
+	buildAgentSystemPrompt: vi.fn(async () => 'system'),
+}))
+
+vi.mock('~/ai/chat/runtime/agent-event-projector', () => ({
+	AgentEventProjector: class {
+		async project() {}
+	},
+}))
+
+vi.mock('~/ai/core/runtime', () => ({
+	prepareMessagesForModel: (
+		_provider: unknown,
+		_modelId: string,
+		messages: unknown,
+	) => messages,
+	resolveLanguageModel: () => ({ model: {} }),
+}))
+
+async function runAgent(sessionMaxTokens?: number) {
+	const session: ChatSession = {
+		schemaVersion: 2,
+		id: 'session',
+		createdAt: 1,
+		updatedAt: 1,
+		...(sessionMaxTokens === undefined
+			? {}
+			: { inferenceParams: { maxTokens: sessionMaxTokens } }),
+		subagents: { master: {} as never },
+	}
+	const toolExecutor = {
+		getAgentDefinition: () => ({}),
+		createTools: vi.fn(async () => ({})),
+		createStableToolsContext: () => ({ app: {} }),
+		prepareReadTracker: () => ({ resetSnapshot: vi.fn() }),
+	}
+	const runner = new AgentRunner(
+		toolExecutor as never,
+		{} as never,
+		{} as never,
+		vi.fn(),
+		{} as never,
+	)
+
+	await runner.runTurn({
+		session,
+		agent: { id: 'master', type: 'master', timeline: [] } as never,
+		provider: { id: 'provider', name: 'Provider' } as never,
+		model: {
+			id: 'model',
+			name: 'Model',
+			limit: { context: 1_000_000, output: 384_000 },
+		} as never,
+		depth: 0,
+		assistantMeta: {},
+		isCancelled: () => false,
+		isDeleted: () => false,
+		buildMessages: async () => [],
+	})
+}
+
+describe('AgentRunner inference options', () => {
+	beforeEach(() => {
+		toolLoopOptions.mockReset()
+	})
+
+	it('uses the configured model output limit by default', async () => {
+		await runAgent()
+
+		expect(toolLoopOptions).toHaveBeenCalledWith(
+			expect.objectContaining({ maxOutputTokens: 384_000 }),
+		)
+	})
+
+	it('prefers an explicit session output limit', async () => {
+		await runAgent(16_000)
+
+		expect(toolLoopOptions).toHaveBeenCalledWith(
+			expect.objectContaining({ maxOutputTokens: 16_000 }),
+		)
+	})
+})

--- a/src/ai/chat/runtime/agent-runner.ts
+++ b/src/ai/chat/runtime/agent-runner.ts
@@ -20,6 +20,7 @@ import { buildAgentSystemPrompt } from '~/ai/chat/prompts'
 import { AgentEventProjector } from '~/ai/chat/runtime/agent-event-projector'
 import type { SessionRuntimeState } from '~/ai/chat/runtime/chat-state'
 import { resolveSummaryContext } from '~/ai/chat/runtime/context-compression'
+import { resolveMaxOutputTokens } from '~/ai/chat/runtime/inference-options'
 import type { ToolExecutor } from '~/ai/chat/runtime/tool-executor'
 import type { SessionStore } from '~/ai/chat/session/session-store'
 import type { ChatAgentState, ChatMessageMeta } from '~/ai/chat/types'
@@ -195,7 +196,10 @@ export class AgentRunner {
 			toolsContext,
 			stopWhen: [isLoopFinished(), repeatedToolCalls, suspendAtStepBoundary],
 			temperature: session.inferenceParams?.temperature,
-			maxOutputTokens: session.inferenceParams?.maxTokens,
+			maxOutputTokens: resolveMaxOutputTokens(
+				session.inferenceParams?.maxTokens,
+				options.model.limit?.output,
+			),
 			prepareStep: async ({ messages, steps }) => {
 				readTracker.resetSnapshot()
 				await projector.project({ type: 'step-start' })

--- a/src/ai/chat/runtime/context-compression.test.ts
+++ b/src/ai/chat/runtime/context-compression.test.ts
@@ -252,6 +252,40 @@ describe('context compression', () => {
 		)
 	})
 
+	it('uses the configured model output limit by default', async () => {
+		const master = createEmptyMasterAgent(1)
+		master.timeline = [message('u1', 'user', 1)]
+		const session: ChatSession = {
+			schemaVersion: 2,
+			id: 'session',
+			createdAt: 1,
+			updatedAt: 1,
+			subagents: { master },
+		}
+		const store = {
+			upsertSessionIndexItem: vi.fn(),
+			persistSession: vi.fn(async () => undefined),
+			persistMetaAndIndex: vi.fn(async () => undefined),
+		}
+		const factory = new MessageFactory({} as never, {} as never, vi.fn())
+
+		await runContextCompression({
+			provider: {} as never,
+			model: {
+				id: 'model',
+				limit: { context: 1_000_000, output: 384_000 },
+			} as never,
+			session,
+			agent: master,
+			store: store as never,
+			messageFactory: factory,
+		})
+
+		expect(generateText).toHaveBeenCalledWith(
+			expect.objectContaining({ maxOutputTokens: 384_000 }),
+		)
+	})
+
 	it('keeps the compaction instruction as a separate final user message', async () => {
 		const master = createEmptyMasterAgent(1)
 		master.timeline = [

--- a/src/ai/chat/runtime/context-compression.ts
+++ b/src/ai/chat/runtime/context-compression.ts
@@ -10,6 +10,7 @@ import {
 } from '~/ai/chat/messages/ui-message'
 import { buildAgentSystemPrompt, COMPRESSION_PROMPT } from '~/ai/chat/prompts'
 import type { ToolExecutor } from '~/ai/chat/runtime/tool-executor'
+import { resolveMaxOutputTokens } from '~/ai/chat/runtime/inference-options'
 import type { SessionStore } from '~/ai/chat/session/session-store'
 import type { AppUIMessage, ChatAgentState } from '~/ai/chat/types'
 import {
@@ -214,7 +215,10 @@ export async function runContextCompression({
 		messages: summarizerMessages,
 		abortSignal,
 		temperature: session.inferenceParams?.temperature,
-		maxOutputTokens: session.inferenceParams?.maxTokens,
+		maxOutputTokens: resolveMaxOutputTokens(
+			session.inferenceParams?.maxTokens,
+			model.limit?.output,
+		),
 	})
 	if (isCancelled?.()) return
 	const summary = response.text.trim() || COMPRESSION_PROMPT

--- a/src/ai/chat/runtime/inference-options.test.ts
+++ b/src/ai/chat/runtime/inference-options.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMaxOutputTokens } from '~/ai/chat/runtime/inference-options'
+
+describe('resolveMaxOutputTokens', () => {
+	it('prefers a valid explicit session limit', () => {
+		expect(resolveMaxOutputTokens(16_000, 384_000)).toBe(16_000)
+	})
+
+	it.each([undefined, 0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+		'falls back to the model limit for invalid session value %s',
+		(sessionLimit) => {
+			expect(resolveMaxOutputTokens(sessionLimit, 384_000)).toBe(384_000)
+		},
+	)
+
+	it.each([undefined, 0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+		'omits invalid model limit %s',
+		(modelLimit) => {
+			expect(resolveMaxOutputTokens(undefined, modelLimit)).toBeUndefined()
+		},
+	)
+})

--- a/src/ai/chat/runtime/inference-options.ts
+++ b/src/ai/chat/runtime/inference-options.ts
@@ -1,0 +1,12 @@
+function isValidTokenLimit(value: number | undefined): value is number {
+	return typeof value === 'number' && Number.isInteger(value) && value >= 1
+}
+
+export function resolveMaxOutputTokens(
+	sessionMaxTokens: number | undefined,
+	modelOutputLimit: number | undefined,
+): number | undefined {
+	if (isValidTokenLimit(sessionMaxTokens)) return sessionMaxTokens
+	if (isValidTokenLimit(modelOutputLimit)) return modelOutputLimit
+	return undefined
+}


### PR DESCRIPTION
## 变更摘要

修复未设置会话级 `inferenceParams.maxTokens` 时，普通 Agent 和上下文压缩未使用模型配置 `limit.output` 的问题。此前两条调用链都会把 `maxOutputTokens: undefined` 交给 AI SDK，提供商可能因此采用较小的默认输出上限；现在会优先使用有效的会话值，否则回退到模型输出上限。

## 实现要点

- 新增共享的 `resolveMaxOutputTokens`，统一普通 Agent 与上下文压缩的解析规则。
- 正整数会话值优先于模型 `limit.output`。
- 会话值无效时回退到有效的模型上限；两者均无效时不传输出上限。
- 增加 SDK 调用边界和解析函数的回归测试，覆盖默认回退、会话覆盖及无效值。

## 代码流程

```mermaid
flowchart TD
    A[开始解析输出 Token 上限] --> B{会话 maxTokens 是正整数}
    B -- 是 --> C[使用会话上限]
    B -- 否 --> D{模型 limit.output 是正整数}
    D -- 是 --> E[使用模型上限]
    D -- 否 --> F[返回 undefined]
    C --> G[传给 ToolLoopAgent 或 generateText]
    E --> G
    F --> G
```

## 修复前失败的原版测试代码

以下用例直接摘自本 PR 新增或修改的回归测试。测试辅助函数 `runAgent()` 使用 `limit.output = 384_000` 且不设置会话上限；上下文压缩用例也使用相同模型上限。

```ts
it('uses the configured model output limit by default', async () => {
	await runAgent()

	expect(toolLoopOptions).toHaveBeenCalledWith(
		expect.objectContaining({ maxOutputTokens: 384_000 }),
	)
})
```

```ts
it('uses the configured model output limit by default', async () => {
	const master = createEmptyMasterAgent(1)
	master.timeline = [message('u1', 'user', 1)]
	const session: ChatSession = {
		schemaVersion: 2,
		id: 'session',
		createdAt: 1,
		updatedAt: 1,
		subagents: { master },
	}
	const store = {
		upsertSessionIndexItem: vi.fn(),
		persistSession: vi.fn(async () => undefined),
		persistMetaAndIndex: vi.fn(async () => undefined),
	}
	const factory = new MessageFactory({} as never, {} as never, vi.fn())

	await runContextCompression({
		provider: {} as never,
		model: {
			id: 'model',
			limit: { context: 1_000_000, output: 384_000 },
		} as never,
		session,
		agent: master,
		store: store as never,
		messageFactory: factory,
	})

	expect(generateText).toHaveBeenCalledWith(
		expect.objectContaining({ maxOutputTokens: 384_000 }),
	)
})
```

在修改生产代码前运行这两组相关测试时，新增的两个默认回退断言失败（`2 failed, 7 passed`）：`ToolLoopAgent` 构造参数和上下文压缩的 `generateText` 参数实际都包含 `maxOutputTokens: undefined`，而预期值为 `384_000`。

## 验证情况

- `vitest run src/ai/chat/runtime/agent-runner.test.ts src/ai/chat/runtime/context-compression.test.ts src/ai/chat/runtime/inference-options.test.ts`：3 个文件、23 个测试通过。
- `vitest run src/ai/chat/runtime`：6 个文件、32 个测试通过。
- 6 个改动文件 ESLint：通过。
- 6 个改动文件 Prettier `--check`：通过。
- 当前 PR 未上报 GitHub Checks；以上为本地验证结果。

## 已知基线问题与实现假设

- Fork PR 当前没有可用的 GitHub CI 结果，因此不将 CI 标记为已通过。
- `tsc -noEmit -skipLibCheck` 在 base 与 PR 头提交上均被既有的 `src/ai/tools/bash/zip.ts:570` 类型错误阻断；两端报错一致，不属于本 PR 回归。
- 假设模型配置 `limit.output` 表示调用方允许的最大输出 Token 数；该值会原样传给 AI SDK，不额外探测提供商能力。
- 有效的会话级 `maxTokens` 被视为显式覆盖，即使它大于模型配置值也不会在此处截断。
- 与 AI SDK 的参数约束一致，仅正整数会被传递；零、负数、非整数和非有限值会回退或被省略。
- 回归测试验证到 AI SDK 参数边界，未包含真实 DeepSeek 端点的端到端请求。

## 关联 Issue

- nutstore/obsidian-nutstore-sync#162
